### PR TITLE
Improves SARIF processing performance + add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Beta
 
 - Refactors SARIF processing for improved performance
+- Add more test cases
 - Upgrade NPM dependencies
 
 ## [3.4.0] 2025-12-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Beta
 
+- Refactors SARIF processing for improved performance
+- Upgrade NPM dependencies
+
 ## [3.4.0] 2025-12-30
 
 - Upgrade NPM dependencies

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,4 +1,4 @@
-export const EXTENSIONS_LANGUAGES = {
+export const EXTENSIONS_LANGUAGES: Record<string, string> = {
   1: 'Groff',
   2: 'Groff',
   3: 'Groff',
@@ -736,8 +736,9 @@ export const EXTENSIONS_LANGUAGES = {
   tu: 'Turing',
   ttl: 'Turtle',
   twig: 'Twig',
-  ts: 'XML',
-  tsx: 'XML',
+  ts: 'TypeScript',
+  tsx: 'TypeScript',
+  // tsx: JSX variant of TypeScript
   upc: 'Unified Parallel C',
   anim: 'Unity3D Asset',
   asset: 'Unity3D Asset',

--- a/src/lib/sarif-builder.spec.ts
+++ b/src/lib/sarif-builder.spec.ts
@@ -132,6 +132,243 @@ test('Create SarifResultBuilder with error', (t) => {
   t.assert(error === true, 'Error should have been triggered');
 });
 
+test('Generate SARIF with multiple runs', (t) => {
+  const sarifBuilder = new SarifBuilder();
+
+  const runBuilder1 = createInitSarifRunBuilder();
+  runBuilder1.addRule(createInitSarifRuleBuilder());
+  runBuilder1.addResult(createInitSarifResultBuilder());
+  sarifBuilder.addRun(runBuilder1);
+
+  const runBuilder2 = new SarifRunBuilder();
+  runBuilder2.initSimple({
+    toolDriverName: 'AnotherTool',
+    toolDriverVersion: '1.2.3',
+  });
+  runBuilder2.addRule(createInitSarifRuleBuilder2());
+  runBuilder2.addResult(createInitSarifResultBuilder2());
+  sarifBuilder.addRun(runBuilder2);
+
+  const outputFile = path.join(
+    os.tmpdir(),
+    'testSarifBuilder-multi-run-' + Math.random() + '.sarif',
+  );
+  sarifBuilder.generateSarifFileSync(outputFile);
+
+  const outputSarifObj: Log = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+  t.is(outputSarifObj?.runs?.length, 2);
+  t.is(outputSarifObj?.runs?.[0]?.tool?.driver?.name, 'MegaLinter');
+  t.is(outputSarifObj?.runs?.[1]?.tool?.driver?.name, 'AnotherTool');
+  t.is(outputSarifObj?.runs?.[0]?.results?.length, 1);
+  t.is(outputSarifObj?.runs?.[1]?.results?.length, 1);
+});
+
+test('Generate SARIF with richer tool and result details', (t) => {
+  const sarifBuilder = new SarifBuilder();
+  const runBuilder = new SarifRunBuilder();
+  runBuilder.initSimple({
+    toolDriverName: 'DetailTool',
+    toolDriverVersion: '9.9.9',
+  });
+
+  const ruleBuilder = new SarifRuleBuilder();
+  ruleBuilder.initSimple({
+    ruleId: 'RICH_RULE',
+    shortDescriptionText: 'Short description',
+    fullDescriptionText: 'Full description with more detail',
+    helpUri: 'https://example.com/rules/RICH_RULE',
+  });
+
+  const resultBuilder = new SarifResultBuilder();
+  resultBuilder.initSimple({
+    level: 'error',
+    messageText: 'Something went wrong',
+    ruleId: 'RICH_RULE',
+    fileUri: 'src/example/file.ts',
+    startLine: 12,
+  });
+
+  runBuilder.addRule(ruleBuilder);
+  runBuilder.addResult(resultBuilder);
+  sarifBuilder.addRun(runBuilder);
+
+  const outputFile = path.join(
+    os.tmpdir(),
+    'testSarifBuilder-detail-' + Math.random() + '.sarif',
+  );
+  sarifBuilder.generateSarifFileSync(outputFile);
+
+  const outputSarifObj: Log = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+  const run = outputSarifObj?.runs?.[0];
+
+  t.is(run?.tool?.driver?.name, 'DetailTool');
+  t.is(run?.tool?.driver?.version, '9.9.9');
+  t.is(run?.tool?.driver?.rules?.[0]?.id, 'RICH_RULE');
+  t.is(
+    run?.tool?.driver?.rules?.[0]?.shortDescription?.text,
+    'Short description',
+  );
+  t.is(
+    run?.tool?.driver?.rules?.[0]?.fullDescription?.text,
+    'Full description with more detail',
+  );
+  t.is(
+    run?.tool?.driver?.rules?.[0]?.helpUri,
+    'https://example.com/rules/RICH_RULE',
+  );
+  t.is(run?.results?.[0]?.level, 'error');
+  t.is(run?.results?.[0]?.message?.text, 'Something went wrong');
+  t.is(run?.results?.[0]?.ruleId, 'RICH_RULE');
+  t.is(
+    run?.results?.[0]?.locations?.[0]?.physicalLocation?.artifactLocation?.uri,
+    'src/example/file.ts',
+  );
+  t.is(
+    run?.results?.[0]?.locations?.[0]?.physicalLocation?.region?.startLine,
+    12,
+  );
+});
+
+test('Build SARIF JSON string with indent', (t) => {
+  const sarifBuilder = new SarifBuilder();
+  const runBuilder = createInitSarifRunBuilder();
+  runBuilder.addRule(createInitSarifRuleBuilder());
+  runBuilder.addResult(createInitSarifResultBuilder());
+  sarifBuilder.addRun(runBuilder);
+
+  const sarifJson = sarifBuilder.buildSarifJsonString({ indent: true });
+  t.true(sarifJson.includes('\n  "runs"'));
+});
+
+test('Build SARIF JSON string throws on invalid markers', (t) => {
+  const sarifBuilder = new SarifBuilder();
+  const runBuilder = new SarifRunBuilder();
+  runBuilder.setToolDriverName(
+    'SARIF_BUILDER_INVALID: Please send the tool name in tool.driver.name property, or call setToolName(name)',
+  );
+  sarifBuilder.addRun(runBuilder);
+
+  t.throws(() => sarifBuilder.buildSarifJsonString(), {
+    message: /SARIF log is invalid/i,
+  });
+});
+
+test('Generate SARIF file async', async (t) => {
+  const sarifBuilder = new SarifBuilder();
+  const sarifRunBuilder = createInitSarifRunBuilder();
+  sarifRunBuilder.addRule(createInitSarifRuleBuilder());
+  sarifRunBuilder.addResult(createInitSarifResultBuilder());
+  sarifBuilder.addRun(sarifRunBuilder);
+
+  const outputFile = path.join(
+    os.tmpdir(),
+    'testSarifBuilder-async-' + Math.random() + '.sarif',
+  );
+  await sarifBuilder.generateSarifFile(outputFile);
+  t.true(fs.existsSync(outputFile));
+});
+
+test('Complete run fields adds artifacts and sets indexes', (t) => {
+  const sarifBuilder = new SarifBuilder();
+  const runBuilder = createInitSarifRunBuilder();
+
+  const ruleA = new SarifRuleBuilder();
+  ruleA.initSimple({
+    ruleId: 'RuleA',
+    shortDescriptionText: 'Rule A short',
+  });
+  const ruleB = new SarifRuleBuilder();
+  ruleB.initSimple({
+    ruleId: 'RuleB',
+    shortDescriptionText: 'Rule B short',
+  });
+
+  const resultA = new SarifResultBuilder();
+  resultA.initSimple({
+    level: 'warning',
+    messageText: 'Result A',
+    ruleId: 'RuleA',
+    fileUri: 'src/one.ts',
+    startLine: 1,
+  });
+  const resultB = new SarifResultBuilder();
+  resultB.initSimple({
+    level: 'error',
+    messageText: 'Result B',
+    ruleId: 'RuleB',
+    fileUri: 'src/two.js',
+    startLine: 2,
+  });
+
+  runBuilder.addRule(ruleA);
+  runBuilder.addRule(ruleB);
+  runBuilder.addResult(resultA);
+  runBuilder.addResult(resultB);
+
+  runBuilder.run.artifacts = [
+    {
+      location: { uri: 'src/one.ts' },
+      sourceLanguage: 'TypeScript',
+    },
+  ];
+
+  sarifBuilder.addRun(runBuilder);
+  const log = sarifBuilder.buildSarifOutput();
+  const run = log.runs[0];
+
+  t.is(run.artifacts?.length, 2);
+  t.truthy(run.artifacts?.find((a) => a.location?.uri === 'src/one.ts'));
+  t.truthy(run.artifacts?.find((a) => a.location?.uri === 'src/two.js'));
+  t.is(run.artifacts?.[1]?.sourceLanguage, 'JavaScript');
+  t.is(run.results?.[0]?.ruleIndex, 0);
+  t.is(run.results?.[1]?.ruleIndex, 1);
+  t.is(
+    run.results?.[0]?.locations?.[0]?.physicalLocation?.artifactLocation?.index,
+    0,
+  );
+  t.is(
+    run.results?.[1]?.locations?.[0]?.physicalLocation?.artifactLocation?.index,
+    1,
+  );
+});
+
+test('SarifRunBuilder initSimple sets informationUri', (t) => {
+  const runBuilder = new SarifRunBuilder();
+  runBuilder.initSimple({
+    toolDriverName: 'UriTool',
+    toolDriverVersion: '1.0.0',
+    url: 'https://example.com/tool',
+  });
+  t.is(runBuilder.run.tool.driver.informationUri, 'https://example.com/tool');
+});
+
+test('SarifRuleBuilder setFullDescriptionText initializes fullDescription', (t) => {
+  const ruleBuilder = new SarifRuleBuilder();
+  ruleBuilder.setFullDescriptionText('Full description text');
+  t.is(ruleBuilder.rule.fullDescription?.text, 'Full description text');
+});
+
+test('SarifResultBuilder initSimple sets explicit region fields', (t) => {
+  const resultBuilder = new SarifResultBuilder();
+  resultBuilder.initSimple({
+    level: 'note',
+    messageText: 'Region detail',
+    ruleId: 'RegionRule',
+    fileUri: 'src/region.ts',
+    startLine: 3,
+    startColumn: 4,
+    endLine: 5,
+    endColumn: 6,
+  });
+
+  const region =
+    resultBuilder.result.locations[0].physicalLocation.region || {};
+  t.is(region.startLine, 3);
+  t.is(region.startColumn, 4);
+  t.is(region.endLine, 5);
+  t.is(region.endColumn, 6);
+});
+
 function createInitSarifRunBuilder() {
   const sarifRunBuilder = new SarifRunBuilder();
   sarifRunBuilder.initSimple({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
-export function setOptionValues(options, object: any) {
-  for (const key of Object.keys(object)) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setOptionValues(options: Record<string, any>, object: Record<string, any>) {
+  for (const key of Object.keys(options)) {
     if (options[key] !== undefined) {
       object[key] = options[key];
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setOptionValues(options: Record<string, any>, object: Record<string, any>) {
+export function setOptionValues(
+  options: Record<string, any>,
+  object: Record<string, any>,
+) {
   for (const key of Object.keys(options)) {
     if (options[key] !== undefined) {
       object[key] = options[key];


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
  Feature (performance improvement), Test, Refactor, Bug fix

- **What is the current behavior?**
  SARIF processing, specifically artifact and rule indexing, can be inefficient due to O(N) array lookups in loops. TypeScript files (`.ts`, `.tsx`) are incorrectly classified as XML. Key development dependencies like `nyc` are outdated.

- **What is the new behavior (if this is a feature change)?**
  Refactors the SARIF `completeRunFields` method to use `Map` and `Set` for O(1) lookups, significantly improving performance for generating large SARIF logs. Adds comprehensive test coverage for various `SarifBuilder` functionalities, including multiple runs, rich detail representation, and indexing logic. Correctly identifies `.ts` and `.tsx` file extensions as TypeScript.

- **Other information**:
  Upgrades the `nyc` dependency to its latest major version and updates other associated testing and coverage tools. Includes cleanup of unused packages in `yarn.lock` for a leaner dependency tree.